### PR TITLE
Markdown list in services

### DIFF
--- a/data/services/cloud.yaml
+++ b/data/services/cloud.yaml
@@ -1,4 +1,7 @@
 weight: 3
 title: "Office365 and Cloud computing"
-description: "Management of Email, Office, SharePoint, Skype, Azure, Security, Licensing<br>Design, implementation, education, optimization"
+description: |
+    - Management of Email, Office, SharePoint, Skype, Azure, Security, Licensing
+    - Design, implementation, education, optimization
+
 icon: "💻" 


### PR DESCRIPTION
Demonstrates how to use a markdown list inside a service's description.

The `cloud.yaml` configuration file is in the [yaml format](http://yaml.org/spec/1.2/spec.html) (spec is quite long, no need to read, but can be used a reference).

By saying `description: |`, I'm denoting that the description field spans multiple (indented!) lines. It takes everything until the next non-indented field (in this case, `icon`) and passes that along to be converted according to markdown rules.

Ask or comment in this thread. Once you feel like you have a hang of it, you can click the green button that says "Merge", which will apply the changes I'm showing so that everyone can see them.